### PR TITLE
Local vars problem deploying a contract with arguments (strict mode)

### DIFF
--- a/lib/web3/contract.js
+++ b/lib/web3/contract.js
@@ -165,6 +165,8 @@ var checkForContractAddress = function(contract, callback){
 var ContractFactory = function (eth, abi) {
     this.eth = eth;
     this.abi = abi;
+    var abi = abi;
+    var eth = eth;
 
     /**
      * Should be called to create new contract on a blockchain
@@ -177,7 +179,7 @@ var ContractFactory = function (eth, abi) {
      * @returns {Contract} returns contract instance
      */
     this.new = function () {
-        var contract = new Contract(this.eth, this.abi);
+        var contract = new Contract(eth, abi);
 
         // parse arguments
         var options = {}; // required!
@@ -193,13 +195,13 @@ var ContractFactory = function (eth, abi) {
             options = args.pop();
         }
 
-        var bytes = encodeConstructorParams(this.abi, args);
+        var bytes = encodeConstructorParams(abi, args);
         options.data += bytes;
 
         if (callback) {
 
             // wait for the contract address adn check if the code was deployed
-            this.eth.sendTransaction(options, function (err, hash) {
+            eth.sendTransaction(options, function (err, hash) {
                 if (err) {
                     callback(err);
                 } else {
@@ -213,7 +215,7 @@ var ContractFactory = function (eth, abi) {
                 }
             });
         } else {
-            var hash = this.eth.sendTransaction(options);
+            var hash = eth.sendTransaction(options);
             // add the transaction hash
             contract.transactionHash = hash;
             checkForContractAddress(contract);


### PR DESCRIPTION
in `lib/web3/contract.js` - _ContractFactory_ constructor

Fix: Use local `abi` and `eth` variables by assigning them in local scope to prevent bug when using ES strict mode (`"use strict"`).

---

To reproduce the bug put "use strict" in your javascript file, try to deploy a contract with at least one parameter in its contstructor, this should be the stacktrace you will get (this is mine on latest node 5):

```
TypeError: Cannot read property 'filter' of undefined
    at encodeConstructorParams (.../node_modules/web3/lib/web3/contract.js:37:15)
    at new (.../node_modules/web3/lib/web3/contract.js:196:21)
```

This is caused because `abi` is undefined and will produce the error on [ this line](https://github.com/makevoid/web3.js/compare/master...contractfactory_local_vars?quick_pull=1#diff-430c9c02bef6a7661c5b4e7b34142f7cL37)

You can see that both `abi` and `eth` will be undefined inside the `this.new {}` closure by putting a console.log or by using a debugger.

Do you think that this can be fixed in another way?
